### PR TITLE
Fix calculate new line

### DIFF
--- a/Pod/Classes/HorizontalFloatingHeaderLayout.swift
+++ b/Pod/Classes/HorizontalFloatingHeaderLayout.swift
@@ -94,7 +94,7 @@ public class HorizontalFloatingHeaderLayout: UICollectionViewLayout {
             
             //
             let size = itemSize(for: indexPath)
-            let newMaxY = currentMinY + size.height
+            let newMaxY = currentMinY
             let origin:CGPoint
             if newMaxY >  availableHeight(atSection: indexPath.section){
                 origin = newLineOrigin(size: size)


### PR DESCRIPTION
Because in line
`currentMinY = frame.maxY + itemSpacing(forSection: indexPath.section)`
frame.maxY =  frame.minY + size.height

If in line `newMaxY = currentMinY + size.height` meaning we added double height
therefore we do not need plus `size.height`